### PR TITLE
Specify a couple of OS-specific parameters

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,8 +2,14 @@
 #
 class logwatch::params {
 
-  $output         = 'stdout'
-  $format         = 'test'
+  $output         = $::osfamily ? {
+    'RedHat' => 'unformatted',
+    default  => 'stdout',
+  }
+  $format         = $::osfamily ? {
+    'RedHat' => 'text',
+    default  => 'test',
+  }
   $mail_to        = [ 'root' ]
   $mail_from      = 'Logwatch'
   $range          = 'Yesterday'


### PR DESCRIPTION
Specify a couple of OS-specific parameters to ensure compatibility with CentOS. The defaults in this module give broken logwatch output on CentOS 6.