### PR TITLE
Manage ignore.conf

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
   symlinks:
     logwatch: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This module requires puppetlabs-stdlib >= 3.2.0
 ###What logwatch affects
 
  * logwatch package.
- * logwatch configuration file.
+ * logwatch configuration files.
 
 ##Usage
 
@@ -54,6 +54,16 @@ This module requires puppetlabs-stdlib >= 3.2.0
  }
 ```
 
+#### Managing `ignore.conf`
+
+Add a regex to `ignore.conf` to suppress that output from the logwatch report
+
+```puppet
+  logwatch::ignore { 'my_rule':
+    regex => 'ignore_lines_that_match_this_regex',
+  }
+```
+
 ##Reference
 
 ###Classes
@@ -61,6 +71,7 @@ This module requires puppetlabs-stdlib >= 3.2.0
 ####Public Classes
 
 * logwatch: Main class, includes all other classes.
+* logwatch::ignore: Manage the contents of `ignore.conf`
 
 ####Private Classes
 
@@ -68,6 +79,8 @@ This module requires puppetlabs-stdlib >= 3.2.0
 * logwatch::config: Handles the configuration file.
 
 ####Parameters
+
+##### `logwatch`
 
 ```
 output
@@ -79,6 +92,12 @@ detail
 service
 package_ensure
 package_name
+```
+
+##### `logwatch::ignore`
+
+```
+regex
 ```
 
 ##Limitations

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,4 +10,16 @@ class logwatch::config inherits logwatch {
     content => template('logwatch/logwatch.conf.erb'),
   }
 
+  concat { 'ignore.conf':
+    path  => '/etc/logwatch/conf/ignore.conf',
+    owner => 'root',
+    group => 'root',
+    mode  => '0644',
+  }
+
+  concat::fragment { 'header':
+    target  => 'ignore.conf',
+    content => "###### REGULAR EXPRESSIONS IN THIS FILE WILL BE TRIMMED FROM REPORT OUTPUT #####\n",
+    order   => '01',
+  }
 }

--- a/manifests/ignore.pp
+++ b/manifests/ignore.pp
@@ -1,0 +1,10 @@
+# add entries to ignore.conf
+define logwatch::ignore (
+  $regex,
+) {
+  concat::fragment { $title:
+    target  => 'ignore.conf',
+    content => "$regex\n",
+    order   => '05',
+  }
+}

--- a/manifests/ignore.pp
+++ b/manifests/ignore.pp
@@ -4,7 +4,7 @@ define logwatch::ignore (
 ) {
   concat::fragment { $title:
     target  => 'ignore.conf',
-    content => "$regex\n",
+    content => "${regex}\n",
     order   => '05',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
Manage `ignore.conf` to be able to suppress lines of output from the logwatch report that match a regex
